### PR TITLE
fix(angular): Implicit mode for api requests

### DIFF
--- a/wibb-angular/src/app/wibb-api.service.ts
+++ b/wibb-angular/src/app/wibb-api.service.ts
@@ -14,9 +14,7 @@ export class WibbApiService {
   readonly apiUrl: string;
   readonly apiHost: string;
 
-  private options: RequestInit = {
-    mode: 'no-cors',
-  };
+  private options: RequestInit = {};
 
   constructor() {
     this.apiHost = PROD_API_HOST;


### PR DESCRIPTION
```js
mode: 'cors', // no-cors, *cors, same-origin
```

Corse mode can be 1 of three things. It's best not to set it and let it determine the approriate mode itself.